### PR TITLE
Disable agent status logging

### DIFF
--- a/patent_agent_demo/fastmcp_config.py
+++ b/patent_agent_demo/fastmcp_config.py
@@ -130,7 +130,9 @@ class FastMCPBroker:
         if agent_name in self.agents:
             self.agents[agent_name].status = status
             self.agents[agent_name].current_task = current_task
-            logger.info(f"Agent {agent_name} status updated: {status.value}")
+            # Only log non-idle status updates to reduce log noise
+            if status != AgentStatus.IDLE:
+                logger.info(f"Agent {agent_name} status updated: {status.value}")
             
     async def get_system_status(self) -> Dict[str, Any]:
         """Get overall system status"""

--- a/patent_agent_demo/message_bus.py
+++ b/patent_agent_demo/message_bus.py
@@ -130,7 +130,9 @@ class FastMCPBroker:
         if agent_name in self.agents:
             self.agents[agent_name].status = status
             self.agents[agent_name].current_task = current_task
-            logger.info(f"Agent {agent_name} status updated: {status.value}")
+            # Only log non-idle status updates to reduce log noise
+            if status != AgentStatus.IDLE:
+                logger.info(f"Agent {agent_name} status updated: {status.value}")
             
     async def get_system_status(self) -> Dict[str, Any]:
         """Get overall system status"""


### PR DESCRIPTION
Filter out 'idle' agent status updates from logs to reduce noise.

---
<a href="https://cursor.com/background-agent?bcId=bc-2258fd2b-2973-4cfc-b329-e9f5cef0fdf4">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-2258fd2b-2973-4cfc-b329-e9f5cef0fdf4">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

